### PR TITLE
Add preauthorize option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Add `preauthorize: *` option to perform authorization prior to resolving fields. ([@palkan][])
+
 ## 0.2.0 (2019-08-15)
 
 - Add ability to specify a field name explicitly. ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This integration includes the following features:
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "action_policy-graphql", "~> 0.1"
+gem "action_policy-graphql", "~> 0.3"
 ```
 
 And then execute:
@@ -95,6 +95,42 @@ class CityType < ::Common::Graphql::Type
   field :events, EventType.connection_type, null: false, authorized_scope: {with: CustomEventPolicy}
 end
 ```
+
+**NOTE:** you cannot use `authorize: *` and `authorized_scope: *` at the same time but you can combine `preauthorize: *` with `authorized_scope: *`.
+
+### `preauthorize: *`
+
+If you want to perform authorization before resolving the field value, you can use `preauthorize: *` option:
+
+```ruby
+field :homes, [Home], null: false, preauthorize: {with: HomePolicy}
+
+def homes
+  Home.all
+end
+```
+
+The code above is equal to:
+
+```ruby
+field :homes, [Home], null: false
+
+def homes
+  authorize! "homes", to: :index?, with: HomePolicy
+  Home.all
+end
+```
+
+**NOTE:** we pass the field's name as the `record` to the policy rule. We assume that preauthorization rules do not depend on
+the record itself and pass the field's name for debugging purposes only.
+
+You can customize the authorization options, e.g. `authorize: {to: :preview?, with: CustomPolicy}`.
+
+**NOTE:** unlike `authorize: *` you MUST specify the `with: SomePolicy` option.
+The default authorization rule depends on the type of the field:
+
+- for lists we use `index?` (configured by `ActionPolicy::GraphQL.default_preauthorize_list_rule` parameter)
+- for _singleton_ fields we use `show?` (configured by `ActionPolicy::GraphQL.default_preauthorize_node_rule` parameter)
 
 ### `expose_authorization_rules`
 

--- a/lib/action_policy/graphql.rb
+++ b/lib/action_policy/graphql.rb
@@ -12,6 +12,16 @@ module ActionPolicy
       # Defaults to `:show?`
       attr_accessor :default_authorize_rule
 
+      # Which rule to use when no specified for preauthorization (e.g. `preauthorize: true`)
+      # of a list-like field.
+      # Defaults to `:index?`
+      attr_accessor :default_preauthorize_list_rule
+
+      # Which rule to use when no specified for preauthorization (e.g. `preauthorize: true`)
+      # of a singleton-like field.
+      # Defaults to `:show?`
+      attr_accessor :default_preauthorize_node_rule
+
       # Whether to raise an exeption if field is not authorized
       # or return `nil`.
       # Defaults to `true`.
@@ -23,6 +33,8 @@ module ActionPolicy
     end
 
     self.default_authorize_rule = :show?
+    self.default_preauthorize_list_rule = :index?
+    self.default_preauthorize_node_rule = :show?
     self.authorize_raise_exception = true
     self.default_authorization_field_prefix = "can_"
   end

--- a/lib/action_policy/graphql/authorized_field.rb
+++ b/lib/action_policy/graphql/authorized_field.rb
@@ -32,6 +32,32 @@ module ActionPolicy
         end
       end
 
+      class PreauthorizeExtension < ::GraphQL::Schema::FieldExtension
+        def initialize(*)
+          super
+          if options[:with].nil?
+            raise ArgumentError, "You must specify the policy for preauthorization: " \
+                                 "`field :#{field.name}, preauthorize: {with: SomePolicy}`"
+          end
+          options[:to] ||=
+            if field.type.list?
+              ::ActionPolicy::GraphQL.default_preauthorize_list_rule
+            else
+              ::ActionPolicy::GraphQL.default_preauthorize_node_rule
+            end
+          options[:raise] = ::ActionPolicy::GraphQL.authorize_raise_exception unless options.key?(:raise)
+        end
+
+        def resolve(context:, object:, arguments:, **_rest)
+          if options[:raise]
+            object.authorize! field.name, **options
+            yield object, arguments
+          elsif object.allowed_to?(options[:to], field.name, options)
+            yield object, arguments
+          end
+        end
+      end
+
       class ScopeExtension < ::GraphQL::Schema::FieldExtension
         def after_resolve(value:, context:, object:, **_rest)
           return value if value.nil?
@@ -40,31 +66,40 @@ module ActionPolicy
         end
       end
 
-      def initialize(*args, authorize: nil, authorized_scope: nil, **kwargs, &block)
+      def initialize(*args, preauthorize: nil, authorize: nil, authorized_scope: nil, **kwargs, &block)
         if authorize && authorized_scope
           raise ArgumentError, "Only one of `authorize` and `authorized_scope` " \
-                               "options could be specified"
+                               "options could be specified. You can use `preauthorize` along with scoping"
         end
 
-        options = authorize || authorized_scope
-
-        if options
-          options = {} if options == true
-
-          extension_class = authorized_scope ? ScopeExtension : AuthorizeExtension
-
-          extension = {extension_class => options}
-
-          extensions = (kwargs[:extensions] ||= [])
-
-          if extensions.is_a?(Hash)
-            extensions.merge!(extension)
-          else
-            extensions << extension
-          end
+        if authorize && preauthorize
+          raise ArgumentError, "Only one of `authorize` and `preauthorize` " \
+                               "options could be specified."
         end
+
+        extensions = (kwargs[:extensions] ||= [])
+
+        add_extension! extensions, AuthorizeExtension, authorize
+        add_extension! extensions, ScopeExtension, authorized_scope
+        add_extension! extensions, PreauthorizeExtension, preauthorize
 
         super(*args, **kwargs, &block)
+      end
+
+      private
+
+      def add_extension!(extensions, extension_class, options)
+        return unless options
+
+        options = {} if options == true
+
+        extension = {extension_class => options}
+
+        if extensions.is_a?(Hash)
+          extensions.merge!(extension)
+        else
+          extensions << extension
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,9 @@
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
+# This turns off per-thread caching in action_policy
+ENV["RACK_ENV"] = "test"
+
 require "i18n"
 require "action_policy-graphql"
 begin


### PR DESCRIPTION
`preathorize: *` allows to perform authorization before resolving the field and thus could be combined with `authorized_scope: *`.

Closes #9