### PR TITLE
Support ActionPolicy 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,13 @@ matrix:
   fast_finish: true
   include:
     - rvm: ruby-head
-      gemfile: gemfiles/graphqlmaster.gemfile
+      gemfile: gemfiles/graphql/master.gemfile
     - rvm: 2.6
-      gemfile: gemfiles/graphqlmaster.gemfile
+      gemfile: gemfiles/graphql/master.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/action_policy/master.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/action_policy/0.3.gemfile
     - rvm: jruby-9.2.5.0
       gemfile: gemfiles/jruby.gemfile
     - rvm: 2.6
@@ -28,6 +32,8 @@ matrix:
       gemfile: Gemfile
   allow_failures:
     - rvm: ruby-head
-      gemfile: gemfiles/graphqlmaster.gemfile
+      gemfile: gemfiles/graphql/master.gemfile
     - rvm: 2.6
-      gemfile: gemfiles/graphqlmaster.gemfile
+      gemfile: gemfiles/graphql/master.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/action_policy/master.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ if File.exist?(local_gemfile)
   # Specify custom action_policy/graphql-ruby version in Gemfile.local
   eval(File.read(local_gemfile)) # rubocop:disable Security/Eval
 else
-  gem "action_policy", "~> 0.3.0"
+  gem "action_policy", "~> 0.4.0"
   gem "graphql", "~> 1.9.3"
 end

--- a/gemfiles/action_policy/0.3.gemfile
+++ b/gemfiles/action_policy/0.3.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "action_policy", "~> 0.3.0"
+
+gemspec path: "../.."

--- a/gemfiles/action_policy/master.gemfile
+++ b/gemfiles/action_policy/master.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "action_policy", github: "palkan/action_policy"
+
+gemspec path: "../.."

--- a/gemfiles/graphql/master.gemfile
+++ b/gemfiles/graphql/master.gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gem "graphql", github: "rmosolgo/graphql-ruby"
 
-gemspec path: ".."
+gemspec path: "../.."


### PR DESCRIPTION
https://github.com/palkan/action_policy/commit/8c4b66f748b9ef9021cab2720d89573a8947cf74#diff-d64a3dfb60ac7d15366c2cdba60682baR11 was a breaking change for action_policy-graphql, because it passes all the options from the field extension through the `authorize!` method, including `:raise`. This now breaks with:

```
ArgumentError:
       unknown keyword: raise
     # .../gems/action_policy-0.4.0/lib/action_policy/behaviours/policy_for.rb:11:in `policy_for'
```

Similarly, we need to filter out `:raise` and `:to` when calling `allowed_to?`.

I've updated the CI config to test against 
* ActionPolicy 0.4 on all supported Rubies (which demonstrates the failure),
* ActionPolicy 0.3 on Ruby 2.6, and
* ActionPolicy master (allowing failures) on Ruby 2.6.