### PR TITLE
fixes `unknown keyword: extensions` error

### DIFF
--- a/lib/action_policy/graphql/authorized_field.rb
+++ b/lib/action_policy/graphql/authorized_field.rb
@@ -86,7 +86,7 @@ module ActionPolicy
                                "options could be specified."
         end
 
-        extensions = (kwargs[:extensions] ||= [])
+        extensions = kwargs.key?(:extensions) ? kwargs[:extensions] : []
 
         add_extension! extensions, AuthorizeExtension, authorize
         add_extension! extensions, ScopeExtension, authorized_scope


### PR DESCRIPTION
This error was raising in `ruby 2.6.4` and `ruby 2.6.5` when `:extensions` keyword doesn't exist.