### PR TITLE
fix unknown_keyword: extensions error

### DIFF
--- a/lib/action_policy/graphql/authorized_field.rb
+++ b/lib/action_policy/graphql/authorized_field.rb
@@ -86,11 +86,13 @@ module ActionPolicy
                                "options could be specified."
         end
 
-        kwargs[:extensions] ||= []
+        extensions = kwargs.key?(:extensions) ? kwargs[:extensions] : []
 
-        add_extension! kwargs[:extensions], AuthorizeExtension, authorize
-        add_extension! kwargs[:extensions], ScopeExtension, authorized_scope
-        add_extension! kwargs[:extensions], PreauthorizeExtension, preauthorize
+        add_extension! extensions, AuthorizeExtension, authorize
+        add_extension! extensions, ScopeExtension, authorized_scope
+        add_extension! extensions, PreauthorizeExtension, preauthorize
+
+        kwargs[:extensions] = extensions
 
         super(*args, **kwargs, &block)
       end

--- a/lib/action_policy/graphql/authorized_field.rb
+++ b/lib/action_policy/graphql/authorized_field.rb
@@ -86,11 +86,11 @@ module ActionPolicy
                                "options could be specified."
         end
 
-        extensions = (kwargs[:extensions] ||= [])
+        kwargs[:extensions] ||= []
 
-        add_extension! extensions, AuthorizeExtension, authorize
-        add_extension! extensions, ScopeExtension, authorized_scope
-        add_extension! extensions, PreauthorizeExtension, preauthorize
+        add_extension! kwargs[:extensions], AuthorizeExtension, authorize
+        add_extension! kwargs[:extensions], ScopeExtension, authorized_scope
+        add_extension! kwargs[:extensions], PreauthorizeExtension, preauthorize
 
         super(*args, **kwargs, &block)
       end


### PR DESCRIPTION
Fixes errors in `ruby 2.6.4` and `ruby 2.6.5` when missing `:extensions` kwarg.