### PR TITLE
Add `authorized_field` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Add `authorized_field: *` option to perform authorization on the base of the upper object policy prior to resolving fields. ([@sponomarev][])
+
 ## 0.3.2 (2019-12-12)
 
 - Fix compatibility with Action Policy 0.4.0 ([@haines][])
@@ -35,3 +37,4 @@ Action Policy helpers there.
 
 [@palkan]: https://github.com/palkan
 [@haines]: https://github.com/haines
+[@sponomarev]: https://github.com/sponomarev

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ class CityType < ::Common::Graphql::Type
 end
 ```
 
-**NOTE:** you cannot use `authorize: *` and `authorized_scope: *` at the same time but you can combine `preauthorize: *` with `authorized_scope: *`.
+**NOTE:** you cannot use `authorize: *` and `authorized_scope: *` at the same time but you can combine `preauthorize: *` or `authorize_field: *` with `authorized_scope: *`.
 
 ### `preauthorize: *`
 
@@ -126,13 +126,39 @@ end
 **NOTE:** we pass the field's name as the `record` to the policy rule. We assume that preauthorization rules do not depend on
 the record itself and pass the field's name for debugging purposes only.
 
-You can customize the authorization options, e.g. `authorize: {to: :preview?, with: CustomPolicy}`.
+You can customize the authorization options, e.g. `preauthorize: {to: :preview?, with: CustomPolicy}`.
 
 **NOTE:** unlike `authorize: *` you MUST specify the `with: SomePolicy` option.
 The default authorization rule depends on the type of the field:
 
 - for lists we use `index?` (configured by `ActionPolicy::GraphQL.default_preauthorize_list_rule` parameter)
 - for _singleton_ fields we use `show?` (configured by `ActionPolicy::GraphQL.default_preauthorize_node_rule` parameter)
+
+### `authorize_field: *`
+
+If you want to perform authorization before resolving the field value _on the base of the upper object_, you can use `authorize_field: *` option:
+
+```ruby
+field :homes, Home, null: false, authorize_field: true
+
+def homes
+  Home.all
+end
+```
+
+The code above is equal to:
+
+```ruby
+field :homes, [Home], null: false
+
+def homes
+  authorize! object, to: :homes?
+  Home.all
+end
+```
+By default we use `#{underscored_field_name}?` authorization rule.
+
+You can customize the authorization options, e.g. `authorize_field: {to: :preview?, with: CustomPolicy}`.
 
 ### `expose_authorization_rules`
 

--- a/lib/action_policy/graphql/authorized_field.rb
+++ b/lib/action_policy/graphql/authorized_field.rb
@@ -100,11 +100,11 @@ module ActionPolicy
       def initialize(*args, preauthorize: nil, authorize: nil, authorized_scope: nil, authorize_field: nil, **kwargs, &block)
         if authorize && authorized_scope
           raise ArgumentError, "Only one of `authorize` and `authorized_scope` " \
-                               "options could be specified. You can use `preauthorize` along with scoping"
+                               "options could be specified. You can use `preauthorize` or `authorize_field` along with scoping"
         end
 
-        if authorize && preauthorize
-          raise ArgumentError, "Only one of `authorize` and `preauthorize` " \
+        if !!authorize == !!preauthorize ? authorize : authorize_field
+          raise ArgumentError, "Only one of `authorize`, `preauthorize` or `authorize_field` " \
                                "options could be specified."
         end
 

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -44,6 +44,14 @@ class PostPolicy < ActionPolicy::Base
     check?(:public?) && allowed_to?(:show?)
   end
 
+  def secret_title?
+    false
+  end
+
+  def silent_secret_title?
+    false
+  end
+
   private
 
   def allow_admins
@@ -102,9 +110,19 @@ end
 
 class PostType < BaseType
   field :title, String, null: false
+  field :secret_title, String, null: false, authorize_field: true
+  field :silent_secret_title, String, null: true, authorize_field: {raise: false}
+  field :another_secret_title, String, null: true, authorize_field: {to: :preview?, with: AnotherPostPolicy}
 
   expose_authorization_rules :edit?, :show?, prefix: "can_"
   expose_authorization_rules :destroy?, prefix: "can_i_"
+
+  def secret_title
+    "Secret #{object.title}"
+  end
+
+  alias silent_secret_title secret_title
+  alias another_secret_title secret_title
 end
 
 class AuthorizedPostType < PostType


### PR DESCRIPTION
This option is useful when we want to perform an authorization check on the base of the upper object policy without actually resolving the field.

Example:

We want to expose `User.email` if the user is not an admin only.

```ruby
class UserType < BaseType
  field :email, String, null: true, authorize_field: {raise: false}
end

class UserPolicy < ActionPolicy::Base
  def email?
    !admin?
  end 

  private

  def admin?
    record.role == :admin
  end
end
```