### PR TITLE
Do not include ActionPolicy::GraphQL::AuthorizedField twice

### DIFF
--- a/lib/action_policy/graphql/behaviour.rb
+++ b/lib/action_policy/graphql/behaviour.rb
@@ -36,7 +36,7 @@ module ActionPolicy
 
         base.authorize :user, through: :current_user
 
-        if base.respond_to?(:field_class)
+        if base.respond_to?(:field_class) && !(base.field_class < ActionPolicy::GraphQL::AuthorizedField)
           base.field_class.prepend(ActionPolicy::GraphQL::AuthorizedField)
           base.include ActionPolicy::GraphQL::Fields
         end


### PR DESCRIPTION
Fixes https://github.com/palkan/action_policy-graphql/issues/34

When `ActionPolicy::GraphQL::Behaviour` is included multiple times (e.g.
in both query type and mutation type) you might end up having
`ActionPolicy::GraphQL::AuthorizedField` included multiple times in base
field class.

It makes difficult to use any other graphql field extensions. We are
using another custom extension for authentication which supposed to run
before authorization but authorization always takes over.

PR checklist:
- [ ] Tests included
- [ ] Documentation updated
- [ ] Changelog entry added
