### PR TITLE
Fix bug with modules reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Fix modules reloading in development. ([@rzaharenkov][])
+
 ## 0.5.1 (2020-10-08)
 
 - Fix mutations authorization (clean up around `authorize_mutation_raise_exception` configuration parameter). ([@rzaharenkov][])

--- a/lib/action_policy/graphql/behaviour.rb
+++ b/lib/action_policy/graphql/behaviour.rb
@@ -36,9 +36,14 @@ module ActionPolicy
 
         base.authorize :user, through: :current_user
 
-        if base.respond_to?(:field_class) && !(base.field_class < ActionPolicy::GraphQL::AuthorizedField)
-          base.field_class.prepend(ActionPolicy::GraphQL::AuthorizedField)
-          base.include ActionPolicy::GraphQL::Fields
+        if base.respond_to?(:field_class)
+          unless base.field_class < ActionPolicy::GraphQL::AuthorizedField
+            base.field_class.prepend(ActionPolicy::GraphQL::AuthorizedField)
+          end
+
+          unless base < ActionPolicy::GraphQL::Fields
+            base.include ActionPolicy::GraphQL::Fields
+          end
         end
 
         base.extend self


### PR DESCRIPTION
Fixes https://github.com/palkan/action_policy-graphql/issues/38

Sad but I have introduced this bug last week in this [PR](https://github.com/palkan/action_policy-graphql/pull/35). So instead of being included twice this modules is not included at all under specific circumstances. I don't know if it possible to cover this by unit-tests, probably not.

PR checklist:

- [ ] Tests included
- [ ] Documentation updated
- [x] Changelog entry added
