### PR TITLE
Fixes authorized deprecation warning for fields with resolver

### DIFF
--- a/lib/action_policy/graphql/authorized_field.rb
+++ b/lib/action_policy/graphql/authorized_field.rb
@@ -39,7 +39,7 @@ module ActionPolicy
         end
 
         def apply
-          self.class.show_authorize_mutation_deprecation if field.mutation
+          self.class.show_authorize_mutation_deprecation if field.mutation && field.mutation < ::GraphQL::Schema::Mutation
 
           @to = extract_option(:to) { ::ActionPolicy::GraphQL.default_authorize_rule }
           @raise = extract_option(:raise) { ::ActionPolicy::GraphQL.authorize_raise_exception }


### PR DESCRIPTION
### What is the purpose of this pull request?

Fixes wrong deprecation warning for fields with `authorize` and `resolver`

### What changes did you make? (overview)

I've added check if resolver is a subclass of mutation

### Is there anything you'd like reviewers to focus on?

mutation is an alias of resolver - https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/schema/field.rb#L64

so we need to add another condition to properly check if it's mutation

I used same approach as here - https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/schema/field.rb#L446

wrong warning can be reproduced by adding new field in schema (not sure if it's worth to add this case to schema it if authorize is deprecated anyway)

```ruby
field :auth_resolved_post, resolver: PostResolver, authorize: true
```

PR checklist:

- [ ] Tests included
- [ ] Documentation updated
- [ ] Changelog entry added
