### PR TITLE
Apply authorized_scope while resolving fields rather than after resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Fix compatibility with graphql-ruby 1.12.4 ([@haines][])
+
 ## 0.5.2 (2020-10-20)
 
 - Fix modules reloading in development. ([@rzaharenkov][])

--- a/lib/action_policy/graphql/authorized_field.rb
+++ b/lib/action_policy/graphql/authorized_field.rb
@@ -114,7 +114,8 @@ module ActionPolicy
       end
 
       class ScopeExtension < Extension
-        def after_resolve(value:, context:, object:, **_rest)
+        def resolve(context:, object:, arguments:, **_rest)
+          value = yield(object, arguments)
           return value if value.nil?
 
           object.authorized_scope(value, **options)


### PR DESCRIPTION
### What is the purpose of this pull request?

Fixes #42 

graphql-ruby 1.12.4 [adds the connections extension before other extensions](https://github.com/rmosolgo/graphql-ruby/pull/3326), meaning that action_policy-graphql is now trying to apply `authorized_scope` to the [`Connection`](https://graphql-ruby.org/api-doc/1.12.4/GraphQL/Pagination/Connection.html) instance rather than the underlying items.

### What changes did you make?

Apply `authorize_scope` in the `resolve` hook of the extension rather than `after_resolve`, so that we have direct access to the underlying items.

### PR checklist

- [ ] ~Tests included~ - the existing tests are sufficient (they currently raise an error when run with graphql-ruby 1.12.4+)
- [ ] ~Documentation updated~ - no change to user-facing behaviour 
- [x] Changelog entry added
