### PR TITLE
feat: preauthorize with #index? on connection types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Preauthorize relay connection types with `index?` instead of `show?`. ([@bbenno][])
+
 ## 0.6.0 (2024-07-08)
 
 - Fix compatibility with Action Policy 0.7.0. ([@palkan][])
@@ -91,3 +93,4 @@ Action Policy helpers there.
 [@sponomarev]: https://github.com/sponomarev
 [@bibendi]: https://github.com/bibendi
 [@rzaharenkov]: https://github.com/rzaharenkov
+[@bbenno]: https://github.com/bbenno

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ You can customize the authorization options, e.g. `preauthorize: {to: :preview?,
 **NOTE:** unlike `authorize: *` you MUST specify the `with: SomePolicy` option.
 The default authorization rule depends on the type of the field:
 
-- for lists we use `index?` (configured by `ActionPolicy::GraphQL.default_preauthorize_list_rule` parameter)
+- for lists and relay connection types we use `index?` (configured by `ActionPolicy::GraphQL.default_preauthorize_list_rule` parameter)
 - for _singleton_ fields we use `show?` (configured by `ActionPolicy::GraphQL.default_preauthorize_node_rule` parameter)
 
 ### `authorize_field: *`

--- a/lib/action_policy/graphql/authorized_field.rb
+++ b/lib/action_policy/graphql/authorized_field.rb
@@ -69,7 +69,7 @@ module ActionPolicy
           end
 
           @to = extract_option(:to) do
-            if field.type.list?
+            if field.type.list? || field.connection?
               ::ActionPolicy::GraphQL.default_preauthorize_list_rule
             else
               ::ActionPolicy::GraphQL.default_preauthorize_node_rule

--- a/spec/action_policy/graphql/authorized_spec.rb
+++ b/spec/action_policy/graphql/authorized_spec.rb
@@ -288,6 +288,23 @@ describe "field extensions", :aggregate_failures do
             .with(PostPolicy)
         end
       end
+
+      context "with relay connection" do
+        let(:query) do
+          %({
+              paginatedPosts {
+                nodes {
+                  title
+                }
+              }
+            })
+        end
+
+        it "is authorized" do
+          expect { subject }.to be_authorized_to(:index?, "paginatedPosts")
+            .with(PostPolicy)
+        end
+      end
     end
 
     context "field" do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -316,6 +316,7 @@ class Schema < GraphQL::Schema
     base_options = {with: PostPolicy, raise: true}
     field :all_posts_new, [PostType], null: false, preauthorize: base_options
     field :all_posts, [PostType], null: false, preauthorize: base_options
+    field :paginated_posts, PostType.connection_type, null: false, preauthorize: base_options
 
     field :secret_posts, [PostType], null: false, preauthorize: {to: :view_secret_posts?, with: PostPolicy, raise: true}
     field :connected_posts, PostType.connection_type, null: false, authorized_scope: true
@@ -342,6 +343,7 @@ class Schema < GraphQL::Schema
 
     alias_method :secret_posts, :posts
     alias_method :all_posts, :posts
+    alias_method :paginated_posts, :posts
     alias_method :connected_posts, :posts
     alias_method :another_connected_posts, :posts
   end)


### PR DESCRIPTION
The `preauthorize: { <...> }` field extension automatically determines the `to:` parameter based on the field type if not provided. Previously it used `index?` in case the field's type is a list and `show?` otherwise.

An alternative to lists are relay connection. Action Policy GraphQL handles them now similar to lists and by default uses `index?` instead of the default `show?`.

PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added
